### PR TITLE
doc: rename html_content to htmlContent

### DIFF
--- a/docs/SendSmtpEmail.md
+++ b/docs/SendSmtpEmail.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **to** | [**Array&lt;SendSmtpEmailTo&gt;**](SendSmtpEmailTo.md) | Mandatory if messageVersions are not passed, ignored if messageVersions are passed. List of email addresses and names (optional) of the recipients. For example, [{\&quot;name\&quot;:\&quot;Jimmy\&quot;, \&quot;email\&quot;:\&quot;jimmy98@example.com\&quot;}, {\&quot;name\&quot;:\&quot;Joe\&quot;, \&quot;email\&quot;:\&quot;joe@example.com\&quot;}] | [optional] 
 **bcc** | [**Array&lt;SendSmtpEmailBcc&gt;**](SendSmtpEmailBcc.md) | List of email addresses and names (optional) of the recipients in bcc | [optional] 
 **cc** | [**Array&lt;SendSmtpEmailCc&gt;**](SendSmtpEmailCc.md) | List of email addresses and names (optional) of the recipients in cc | [optional] 
-**html_content** | **String** | HTML body of the message ( Mandatory if &#39;templateId&#39; is not passed, ignored if &#39;templateId&#39; is passed ) | [optional] 
+**htmlContent** | **String** | HTML body of the message ( Mandatory if &#39;templateId&#39; is not passed, ignored if &#39;templateId&#39; is passed ) | [optional] 
 **textContent** | **String** | Plain Text body of the message ( Ignored if &#39;templateId&#39; is passed ) | [optional] 
 **subject** | **String** | Subject of the message. Mandatory if &#39;templateId&#39; is not passed | [optional] 
 **reply_to** | [**SendSmtpEmailReplyTo**](SendSmtpEmailReplyTo.md) |  | [optional] 


### PR DESCRIPTION
Detected from `{"code":"missing_parameter","message":"Either of htmlContent or textContent is required"}` error.